### PR TITLE
Add support for Unix wildcard and multiple platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ${GITHUB_REF##*/} ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, ${GITHUB_REF##*/} ]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main, ${GITHUB_REF##*/} ]
+    branches: [ main, add-unix-wildcard-and-multiple-platforms ]
   pull_request:
-    branches: [ main, ${GITHUB_REF##*/} ]
+    branches: [ main, add-unix-wildcard-and-multiple-platforms ]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm test

--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ or directly from the npm run script like this:
 npm run foo -- arg1 arg2
 ```
 
+You can use the "*" wildcard to match all Unix platforms:
+
+```json
+"cross-os": {
+  "chmodux": {
+    "win32": "",
+    "*": "chmod u+x main.js"
+  }
+}
+```
+
+You can also use comma-separated values to match multiple platforms:
+
+```json
+"cross-os": {
+  "chmodux": {
+    "win32": "",
+    "darwin,freebsd,linux,sunos": "chmod u+x main.js"
+  }
+}
+```
 
 ## License 
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -38,7 +38,23 @@ const pipeline = new Promise<string>(resolve => {
     }
 
     try {
-        return Promise.resolve({ command: config[ property ][ script ][ platform ], params, script })
+        let command = config[ property ][ script ][ platform ]
+
+        if (!command && platform !== 'win32') {
+            command = config[ property ][ script ]['*']
+        }
+
+        if (!command) {
+            const platforms = Object.keys(config[ property ][ script ])
+            for (const p of platforms) {
+                if (p.split(',').includes(platform)) {
+                    command = config[ property ][ script ][ p ]
+                    break
+                }
+            }
+        }
+
+        return Promise.resolve({ command, params, script })
     } catch (e) {
         throw script
     }

--- a/test/package.json
+++ b/test/package.json
@@ -3,12 +3,14 @@
     "first": {
       "win32": "echo hello from win32",
       "linux": "echo hello from linux",
-      "darwin": "echo hello from darwin"
+      "darwin": "echo hello from darwin",
+      "*": "echo hello from unix"
     },
     "first-with-params": {
       "win32": "echo hello from win32, I have arguments:",
       "linux": "echo hello from linux, I have arguments:",
-      "darwin": "echo hello from darwin, I have arguments:"
+      "darwin": "echo hello from darwin, I have arguments:",
+      "*": "echo hello from unix, I have arguments:"
     },
     "second": {},
     "second-with-params": {},
@@ -37,24 +39,28 @@
     "fifth": {
       "win32": "echo hello from cross-os win32",
       "linux": "echo hello from cross-os linux",
-      "darwin": "echo hello from cross-os darwin"
+      "darwin": "echo hello from cross-os darwin",
+      "*": "echo hello from cross-os unix"
     },
     "fifth-with-params": {
       "win32": "echo hello from cross-os win32, I have arguments:",
       "linux": "echo hello from cross-os linux, I have arguments:",
-      "darwin": "echo hello from cross-os darwin, I have arguments:"
+      "darwin": "echo hello from cross-os darwin, I have arguments:",
+      "*": "echo hello from cross-os unix, I have arguments:"
     },
     "sixth": "echo i should not been seen",
     "sixth-with-params": "echo i should not been seen and niether the following arguments:",
     "foo": {
       "win32": "echo bar from win32",
       "linux": "echo bar from linux",
-      "darwin": "echo bar from darwin"
+      "darwin": "echo bar from darwin",
+      "darwin,freebsd,linux,sunos": "echo bar from unix"
     },
     "foo-with-params": {
       "win32": "echo bar from win32, I have arguments:",
       "linux": "echo bar from linux, I have arguments:",
-      "darwin": "echo bar from darwin, I have arguments:"
+      "darwin": "echo bar from darwin, I have arguments:",
+      "darwin,freebsd,linux,sunos": "echo bar from unix, I have arguments:"
     }
   }
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -261,4 +261,32 @@ describe('Loader', () => {
         })
     })
 
+    it('should run the correct script for wildcard "*" on Unix platforms', () => {
+        if (platform !== 'win32') {
+            const stdout = execSync(`node ${cross} first`)
+            expect(stdout.toString()).to.match(/hello from unix/)
+        }
+    })
+
+    it('should run the correct script for wildcard "*" on Unix platforms and pass parameters', () => {
+        if (platform !== 'win32') {
+            const stdout = execSync(`node ${cross} first-with-params -- First Second Third`)
+            expect(stdout.toString()).to.match(/hello from unix, I have arguments: First Second Third/)
+        }
+    })
+
+    it('should run the correct script for comma-separated values on Unix platforms', () => {
+        if (platform !== 'win32') {
+            const stdout = execSync(`node ${cross} foo`)
+            expect(stdout.toString()).to.match(/bar from unix/)
+        }
+    })
+
+    it('should run the correct script for comma-separated values on Unix platforms and pass parameters', () => {
+        if (platform !== 'win32') {
+            const stdout = execSync(`node ${cross} foo-with-params -- First Second Third`)
+            expect(stdout.toString()).to.match(/bar from unix, I have arguments: First Second Third/)
+        }
+    })
+
 })


### PR DESCRIPTION
Add support for wildcard "*" and comma-separated values for platform-specific commands.

* **source/index.ts**
  - Add logic to handle "*" wildcard for Unix platforms.
  - Add logic to handle comma-separated values for multiple platforms.

* **test/package.json**
  - Add test cases for "*" wildcard.
  - Add test cases for comma-separated values.

* **test/test.ts**
  - Add unit tests for "*" wildcard on Unix platforms.
  - Add unit tests for comma-separated values on Unix platforms.

* **README.md**
  - Update documentation to include usage of "*" wildcard.
  - Update documentation to include usage of comma-separated values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/milewski/cross-os?shareId=b3deeb09-8efe-4416-9d4e-22899731689f).